### PR TITLE
D3 활용 국내 시도, 읍면동, 구 단위 경계 시각화 모듈 추가

### DIFF
--- a/d3.html
+++ b/d3.html
@@ -15,6 +15,13 @@
         <!--<script type="text/javascript" src="./js/openGDSMobile/d3chart.js"></script>-->
         <script type="text/javascript" src="./js/openGDSMobile/OGDSM.js"></script>
         <script type="text/javascript" src="./js/openGDSMobile/OGDSM_chartVisualization.js"></script>
+        <script type="text/javascript" src="./js/openGDSMobile/d3chart.js"></script>
+
+<script src="http://d3js.org/topojson.v1.min.js"></script>
+<!-- <script src="http://d3js.org/d3.geo.projection.v0.min.js" > </script> -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/topojson/1.6.19/topojson.min.js" > </script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3-geo-projection/0.2.15/d3.geo.projection.js" > </script>
+
 
 		<style>
 		#d3_chart {
@@ -26,8 +33,78 @@
 		  margin-top: 20px;
 		  margin-right: 0px;*/
 		  color: white;
-		  height:500px;
+		  height:450px;
 		}
+		
+		.sido_Busan{
+  			fill: #d3dfe4;
+  			fill-opacity: .5;
+		}
+		.sido_Chungcheongbuk-do{
+  			fill: #5574a6;
+  			fill-opacity: .5;
+		}
+		.sido_Chungcheongnam-do{
+  			fill: #329262;
+  			fill-opacity: .5;
+		}
+		.sido_Daegu{
+  			fill: #8b0707;
+  			fill-opacity: .5;
+		}
+		.sido_Daejeon{
+  			fill: #e67300;
+  			fill-opacity: .5;
+		}
+		.sido_Gangwon-do{
+  			fill: #6633cc;
+  			fill-opacity: .5;
+		}
+		.sido_Gwangju{
+  			fill: #aaaa11;
+  			fill-opacity: .5;
+		}
+		.sido_Gyeongsangbuk-do{
+  			fill: #22aa99;
+  			fill-opacity: .5;
+		}
+		.sido_Gyeonggi-do{
+  			fill: #994499;
+  			fill-opacity: .5;
+		}
+		.sido_Gyeongsangnam-do{
+  			fill: #b82e2e;
+  			fill-opacity: .5;
+		}
+		.sido_Incheon{
+  			fill: #66aa00;
+  			fill-opacity: .5;
+		}
+		.sido_Jeju-do{
+  			fill: #dd4477;
+  			fill-opacity: .5;
+		}
+		.sido_Jeollabuk-do{
+  			fill: #ff9900;
+  			fill-opacity: .5;
+		}
+		.sido_Jeollanam-do{
+  			fill: #f93c3c;
+  			fill-opacity: .5;
+		}
+		.sido_Sejong-si{
+  			fill: #18d06e;
+  			fill-opacity: .5;
+		}
+		.sido_Seoul{
+  			fill: #e28bb8;
+  			fill-opacity: .5;
+		}
+		.sido_Ulsan{
+  			fill: #e28bb8;
+  			fill-opacity: .5;
+		}
+		
 		</style>
 
         <script>
@@ -74,9 +151,9 @@
                         });
                         //chartObj.vBarChart('d3_chart');
                 		//chartObj.hBarChart('d3_chart');
-                        //chartObj.lineChart('d3_chart');
+                        chartObj.lineChart('d3_chart');
                         //chartObj.areaChart('d3_chart');
-                        chartObj.pieChart('d3_chart');
+                        //chartObj.pieChart('d3_chart');
 
                 	},
                 	error : function (e){
@@ -173,8 +250,19 @@
                 	}
                 });
             }
+			
+           // dataPortal5();
             
-            dataPortal();
+           $(function(){
+        	   
+        	   //kMap = function (divId, geodata, center_lat, center_lon, map_scale)
+        	   //geodata = ["SIDO", "DONG", "GU"]	
+        	   //center_lat, center_lon = Latitude, Longitude
+        	   
+               var chartObj = new OGDSM.chartVisualization();
+               chartObj.kMap('d3_chart', "GU", 34., 131., 3000); 
+           }); 
+            
         </script>
     </head>
     <body>

--- a/js/openGDSMobile/OGDSM_chartVisualization.js
+++ b/js/openGDSMobile/OGDSM_chartVisualization.js
@@ -15,12 +15,6 @@ OGDSM.namesapce('chartVisualization');
     */
     OGDSM.chartVisualization = function (jsonData, options) {
         options = (typeof (options) !== 'undefined') ? options : {};
-        if (typeof (options.rootKey) === 'undefined' ||
-                typeof (options.labelKey) === 'undefined' ||
-                typeof (options.valueKey) === 'undefined') {
-            console.error('Please input option values : rootKey, label, value');
-            return null;
-        }
         this.defaults = {
             rootKey : null,
             labelKey : null,
@@ -28,20 +22,29 @@ OGDSM.namesapce('chartVisualization');
             max : null,
             min : null
         };
-        this.jsonData = jsonData;
-        this.data = jsonData[options.rootKey];
         this.defaults = OGDSM.applyOptions(this.defaults, options);
-        var d = null;
-        this.defaults.max = this.defaults.min = this.data[0][options.valueKey];
-        for (d in this.data) {
-            if (this.data.hasOwnProperty(d)) {
-                this.defaults.max = Math.max(this.data[d][options.valueKey], this.defaults.max);
-                this.defaults.min = Math.min(this.data[d][options.valueKey], this.defaults.max);
+        if (typeof (jsonData) !== 'undefined'){
+            if (typeof (options.rootKey) === 'undefined' ||
+                    typeof (options.labelKey) === 'undefined' ||
+                    typeof (options.valueKey) === 'undefined') {
+                console.error('Please input option values : rootKey, label, value');
+                return null;
             }
+	        this.jsonData = jsonData;
+	        this.data = jsonData[options.rootKey];
+	        this.defaults = OGDSM.applyOptions(this.defaults, options);
+	        var d = null;
+	        this.defaults.max = this.defaults.min = this.data[0][options.valueKey];
+	        for (d in this.data) {
+	            if (this.data.hasOwnProperty(d)) {
+	                this.defaults.max = Math.max(this.data[d][options.valueKey], this.defaults.max);
+	                this.defaults.min = Math.min(this.data[d][options.valueKey], this.defaults.max);
+	            }
+	        }
+	        this.defaults.max = (typeof (options.max) !== 'undefined') ? options.max : this.defaults.max;
+	        this.defaults.min = (typeof (options.min) !== 'undefined') ? options.min : this.defaults.min;
+
         }
-        this.defaults.max = (typeof (options.max) !== 'undefined') ? options.max : this.defaults.max;
-        this.defaults.min = (typeof (options.min) !== 'undefined') ? options.min : this.defaults.min;
-        console.log(this.defaults);
     };
     OGDSM.chartVisualization.prototype = {
         constructor : OGDSM.chartVisualization,

--- a/js/openGDSMobile/d3chart.js
+++ b/js/openGDSMobile/d3chart.js
@@ -406,3 +406,56 @@ areaChart = function (divId, data, scale, range, color) {
 };
 
 
+
+OGDSM.chartVisualization.prototype.kMap = function (divId, geodata, center_lat, center_lon, map_scale) {
+    var rootDiv = $('#'+divId);
+    rootDiv.empty();
+    
+    var svg = d3.select('#'+divId)
+    			.append('svg')
+    			.attr("width" , 500)
+    			.attr("height", 600);
+    
+    baseGeoDataUrl = "http://localhost:8080/mobile/geoBasedData/" + geodata + ".json";
+    
+    d3.json(baseGeoDataUrl, function(error, topology) {
+    	  if (error) {
+    	    return console.error(error);
+    	  } else {
+    		  
+    		  var projection = d3.geo.mercator()
+    		  					 .center([center_lon, center_lat])
+    		  					 .scale(map_scale);
+    		  var path = d3.geo.path()
+    		  		   	   .projection(projection);
+
+    		  var g = svg.append("g");
+    		  
+    		  if(geodata == "SIDO"){
+    			  g.selectAll("path")
+    			   .data(topojson.feature(topology, topology.objects.All_TL_SCCO_CTPRVN_4326).features)
+                   .enter().append("path")
+                   .attr("class", function(d) { return "sido_" + d.properties.CTP_ENG_NM; })
+                   .style("fill", function(d) { return "#" + Math.random().toString(16).slice(2, 8); })
+                   .attr("d", path); 
+    		  }
+    		  else if(geodata == "GU"){
+    			  g.selectAll("path")
+    			   .data(topojson.feature(topology, topology.objects.All_TL_SCCO_SIG_4326).features)
+                   .enter().append("path")
+                   .attr("class", function(d) { return "gu_" + d.properties.SIG_ENG_NM; })
+                   .style("fill", function (d) { return "#" + Math.random().toString(16).slice(2, 8); })
+                   .attr("d", path);  
+    		  }
+    		  else if(geodata == "DONG"){
+    			  g.selectAll("path")
+    			   .data(topojson.feature(topology, topology.objects.All_TL_SCCO_EMD_4326).features)
+                   .enter().append("path")
+                   .attr("class", function(d) { return "dong_" + d.properties.EMD_ENG_NM; })
+                   .style("fill", function (d) { return "#" + Math.random().toString(16).slice(2, 8); })
+                   .attr("d", path);  
+    		  }
+    	  }
+    });
+};
+


### PR DESCRIPTION
1. 사용 방법

//kMap = function (divId, geodata, center_lat, center_lon, map_scale)
//geodata = ["SIDO", "DONG", "GU"]	
//center_lat, center_lon = Latitude, Longitude
        	   
var chartObj = new OGDSM.chartVisualization();
chartObj.kMap('d3_chart', "GU", 34., 131., 3000); 

2. 색상

.style("fill", function (d) { return "#" +
Math.random().toString(16).slice(2, 8); })
위 코드를 통해 임의의 색상으로 시각화 됨

.sido_Busan{
  	fill: #d3dfe4;
  	fill-opacity: .5;
}
.sido_Chungcheongbuk-do{
  	fill: #5574a6;
  	fill-opacity: .5;
}
.sido_Chungcheongnam-do{
  	fill: #329262;
  	fill-opacity: .5;
}
...
...

또는 위와 같은 방식으로 색상 지정 가능